### PR TITLE
Add layout preserving helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,24 @@ output result is the following:
 
 <img src="https://user-images.githubusercontent.com/209884/84148813-7aca8680-aa9a-11ea-8fc9-37dece2ebdac.png"></img>
 
+### 5.2 Merge YAML while preserving layout
+
+Use `MergeYAML` when you need to add data to an existing document without losing the original order or blank lines.
+
+```go
+base := []byte(`a: 1\n\nb: 2\n`)
+patch := []byte(`c: 3`)
+out, err := yaml.MergeYAML(base, patch)
+if err != nil {
+    panic(err)
+}
+fmt.Println(string(out))
+// a: 1
+//
+// b: 2
+// c: 3
+```
+
 
 # Tools
 

--- a/layout.go
+++ b/layout.go
@@ -1,0 +1,39 @@
+package yaml
+
+import (
+	"github.com/goccy/go-yaml/ast"
+	"github.com/goccy/go-yaml/internal/format"
+	"github.com/goccy/go-yaml/parser"
+)
+
+// ParseWithComments parses YAML text and keeps comment tokens in the AST.
+func ParseWithComments(b []byte) (*ast.File, error) {
+	return parser.ParseBytes(b, parser.ParseComments)
+}
+
+// FormatFile reconstructs the YAML text from the given AST.
+// The order of keys and blank lines are preserved.
+func FormatFile(f *ast.File) []byte {
+	return []byte(format.FormatFile(f))
+}
+
+// MergeYAML merges the YAML source of src into base while preserving layout.
+func MergeYAML(base, src []byte) ([]byte, error) {
+	baseFile, err := parser.ParseBytes(base, parser.ParseComments)
+	if err != nil {
+		return nil, err
+	}
+	srcFile, err := parser.ParseBytes(src, parser.ParseComments)
+	if err != nil {
+		return nil, err
+	}
+	for i, doc := range srcFile.Docs {
+		if i >= len(baseFile.Docs) {
+			break
+		}
+		if err := ast.Merge(baseFile.Docs[i].Body, doc.Body); err != nil {
+			return nil, err
+		}
+	}
+	return []byte(format.FormatFile(baseFile)), nil
+}


### PR DESCRIPTION
## Summary
- add helpers for parsing and formatting while preserving layout
- support merging yaml documents without losing ordering or blank lines
- document new `MergeYAML` helper

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68595b60df1083289a0f776f1c3749bb