### PR TITLE
Add layout preserving helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.16.0 - 2025-06-23
+
+### New Features
+
+- Preserve layout with ParseWithComments, FormatFile, and MergeYAML helpers
+
 # 1.11.2 - 2023-09-15
 
 ### Fix bugs

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ By the way, libraries such as [ghodss/yaml](https://github.com/ghodss/yaml) and 
   - The main maintainer is [@goccy](https://github.com/goccy), but we are also building a system to develop as a team with trusted developers
   - Since it is written from scratch, the code is easy to read for Gophers
 - An API structure that allows the use of not only `Encoder`/`Decoder` but also `Tokenizer` and `Parser` functionalities.
-  - [lexer.Tokenize](https://pkg.go.dev/github.com/goccy/go-yaml@v1.15.4/lexer#Tokenize)
-  - [parser.Parse](https://pkg.go.dev/github.com/goccy/go-yaml@v1.15.4/parser#Parse)
+  - [lexer.Tokenize](https://pkg.go.dev/github.com/goccy/go-yaml@v1.16.0/lexer#Tokenize)
+  - [parser.Parse](https://pkg.go.dev/github.com/goccy/go-yaml@v1.16.0/parser#Parse)
 - Filtering, replacing, and merging YAML content using YAML Path
 - Reversible transformation without using the AST for YAML that includes Anchors, Aliases, and Comments
 - Customize the Marshal/Unmarshal behavior for primitive types and third-party library types ([RegisterCustomMarshaler](https://pkg.go.dev/github.com/goccy/go-yaml#RegisterCustomMarshaler), [RegisterCustomUnmarshaler](https://pkg.go.dev/github.com/goccy/go-yaml#RegisterCustomUnmarshaler))
@@ -388,6 +388,24 @@ b: "hello"
 output result is the following:
 
 <img src="https://user-images.githubusercontent.com/209884/84148813-7aca8680-aa9a-11ea-8fc9-37dece2ebdac.png"></img>
+
+### 5.2 Merge YAML while preserving layout
+
+Use `MergeYAML` when you need to add data to an existing document without losing the original order or blank lines.
+
+```go
+base := []byte(`a: 1\n\nb: 2\n`)
+patch := []byte(`c: 3`)
+out, err := yaml.MergeYAML(base, patch)
+if err != nil {
+    panic(err)
+}
+fmt.Println(string(out))
+// a: 1
+//
+// b: 2
+// c: 3
+```
 
 
 # Tools

--- a/docs/playground/go.mod
+++ b/docs/playground/go.mod
@@ -5,7 +5,7 @@ go 1.22.8
 require (
 	github.com/goccy/go-graphviz v0.2.10-0.20250109095217-4ceff9e58e1a
 	github.com/goccy/go-json v0.10.4
-	github.com/goccy/go-yaml v1.15.13
+	github.com/goccy/go-yaml v1.16.0
 )
 
 require (

--- a/layout.go
+++ b/layout.go
@@ -1,0 +1,39 @@
+package yaml
+
+import (
+	"github.com/goccy/go-yaml/ast"
+	"github.com/goccy/go-yaml/internal/format"
+	"github.com/goccy/go-yaml/parser"
+)
+
+// ParseWithComments parses YAML text and keeps comment tokens in the AST.
+func ParseWithComments(b []byte) (*ast.File, error) {
+	return parser.ParseBytes(b, parser.ParseComments)
+}
+
+// FormatFile reconstructs the YAML text from the given AST.
+// The order of keys and blank lines are preserved.
+func FormatFile(f *ast.File) []byte {
+	return []byte(format.FormatFile(f))
+}
+
+// MergeYAML merges the YAML source of src into base while preserving layout.
+func MergeYAML(base, src []byte) ([]byte, error) {
+	baseFile, err := parser.ParseBytes(base, parser.ParseComments)
+	if err != nil {
+		return nil, err
+	}
+	srcFile, err := parser.ParseBytes(src, parser.ParseComments)
+	if err != nil {
+		return nil, err
+	}
+	for i, doc := range srcFile.Docs {
+		if i >= len(baseFile.Docs) {
+			break
+		}
+		if err := ast.Merge(baseFile.Docs[i].Body, doc.Body); err != nil {
+			return nil, err
+		}
+	}
+	return []byte(format.FormatFile(baseFile)), nil
+}


### PR DESCRIPTION
## Summary
- add helpers for parsing and formatting while preserving layout
- support merging yaml documents without losing ordering or blank lines
- document new `MergeYAML` helper
- bump library version to v1.16.0

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68595b60df1083289a0f776f1c3749bb